### PR TITLE
first-commit

### DIFF
--- a/kubernetes.tf
+++ b/kubernetes.tf
@@ -1,0 +1,72 @@
+locals {
+  profiles = flatten([
+    for namespace, service_accounts in var.workload_identity_profiles :
+    [for config in service_accounts : {
+      name : element(split("@", config.email), 0)
+      email : config.email,
+      automount_service_account_token : config.automount_service_account_token,
+      create_service_account_token : config.create_service_account_token,
+      namespace : namespace,
+      project_id : element(split(".", element(split("@", config.email), 1)), 0)
+    }]
+  ])
+  workload_identity_profiles = { for profile in local.profiles : "${profile.namespace}/${profile.email}" => profile }
+}
+
+# The namespaces to create
+resource "kubernetes_namespace" "namespaces" {
+  for_each = toset(concat([
+    "sre",
+    "argocd",
+    "cert-manager",
+    "backend",
+    "frontend",
+    "kyverno",
+    "policy-reporter",
+    "goldilocks",
+  ], var.namespaces))
+  metadata {
+    name        = each.value
+    annotations = { "protected" = "yes" }
+    labels = {
+      "goldilocks.fairwinds.com/enabled" = "true"
+    }
+  }
+}
+
+# Service account tokens - if mounting is enabled -> should avoid this if possible
+resource "kubernetes_secret_v1" "tokens" {
+  depends_on = [
+    kubernetes_service_account.service_accounts
+  ]
+  for_each = { for k, v in local.workload_identity_profiles : k => v if v.automount_service_account_token && v.create_service_account_token }
+
+  metadata {
+    name = "${each.value.name}-service-account-token"
+    annotations = {
+      "kubernetes.io/service-account.name" = each.value.name
+    }
+    namespace = each.value.namespace
+  }
+
+  type = "kubernetes.io/service-account-token"
+}
+
+# The Kubernetes service account with the WLI annotation to enable workload identity for the defined GCP service accounts
+resource "kubernetes_service_account" "service_accounts" {
+  depends_on = [
+    kubernetes_namespace.namespaces,
+  ]
+  for_each = local.workload_identity_profiles
+
+  metadata {
+    name      = each.value.name
+    namespace = each.value.namespace
+    annotations = {
+      "iam.gke.io/gcp-service-account" = each.value.email
+    }
+  }
+
+  automount_service_account_token = each.value.automount_service_account_token
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,21 @@
+variable "workload_identity_profiles" {
+  description = "Profiles used to create kubernetes service accounts with accompanying workload identity labels."
+  type = map(
+    list(
+      object(
+        {
+          email                           = string
+          create_service_account_token    = optional(bool, false)
+          automount_service_account_token = optional(bool, false)
+        }
+      )
+    )
+  )
+  default = {}
+}
+
+variable "namespaces" {
+  description = "Namespaces to create in the GKE cluster."
+  type        = list(string)
+  default     = []
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.3.8"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6"
+    }
+  }
+}


### PR DESCRIPTION
Initial config for the module. This module is meant to be paired with the clusters module to provide a way to add Kubernetes resources to an existing GKE cluster. This module will help decouple the clusters module from the kubernetes resources themselves as due to the "strangeness" of the kubernetes terraform provider, it is far more convenient to have these configurations separated. It helps make the creation of the resources and especially their deletion much more streamlined (though not entirely perfect, this provider just sucks). 