### PR TITLE
Add ability to define storage class

### DIFF
--- a/kubernetes.tf
+++ b/kubernetes.tf
@@ -70,3 +70,16 @@ resource "kubernetes_service_account" "service_accounts" {
   automount_service_account_token = each.value.automount_service_account_token
 }
 
+# Storage classes
+resource "kubernetes_storage_class" "filestore_storage_class" {
+  count = var.filestore_storage_class ? 1 : 0
+
+  metadata {
+    name = "filestore"
+  }
+  storage_provisioner = "filestore.csi.storage.gke.io"
+  parameters = {
+    tier    = var.addons.gcp_filestore_csi_driver_config.tier
+    network = "gke-application-cluster-vpc"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -19,3 +19,9 @@ variable "namespaces" {
   type        = list(string)
   default     = []
 }
+
+variable "filestore_storage_class" {
+  description = "Enable the GKE Filestore CSI driver."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This is to help with environments where we needed to enable a filestore csi driver. This change helps move the config out of the main cluster module